### PR TITLE
Prefetch and cache images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  font-family: 'Lato', sans-serif;
 }
 
 .root {
@@ -17,12 +18,32 @@ body {
   filter: blur(3px);
   position: absolute;
   background-size: cover;
+  background-position: center;
   background-color: rgba(230,230,230,0.7);
 }
 
 .background.loaded {
   opacity: 1;
   filter: blur(0);
-  transition: filter .2s .1s cubic-bezier(0.25, 0.46, 0.45, 0.94),
-              opacity .3s .1s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  transition: filter .1s .1s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+              opacity .2s .1s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.background-info {
+  left: 20px;
+  bottom: 20px;
+  width: 200px;
+  line-height: 30px;
+  font-size: 0.8rem;
+  color: #aaaaaa;
+  position: absolute;
+}
+
+.background-info-link,
+.background-info-link:link,
+.background-info-link:visited,
+.background-info-link:hover,
+.background-info-link:active {
+  color: #cccccc;
+  text-decoration-line: none;
 }

--- a/index.html
+++ b/index.html
@@ -5,12 +5,18 @@
   <title></title>
   <meta charset="utf-8" />
   <link href="css/style.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Lato:400,700" rel="stylesheet">
   <script defer src="js/index.js"></script>
 </head>
 
 <body>
   <div class="root">
     <div class="background"></div>
+    <div class="overlays">
+      <div class="background-info">
+        <a class="background-info-link"></a>
+      </div>
+    </div>
   </div>
 </body>
 

--- a/js/index.js
+++ b/js/index.js
@@ -1,39 +1,134 @@
 class NewTab {
   constructor({
-    backgroundContainer = document.querySelector('.background')
+    backgroundContainer = document.querySelector('.background'),
+    backgroundInfoContainer = document.querySelector('.background-info-link'),
   } = {}) {
     this.element = {
-      background: backgroundContainer
+      background: backgroundContainer,
+      backgroundInfo: backgroundInfoContainer,
     };
+    this.prefetchPostfix = 'yuman-prefetch-v1';
+    this.prefetchListing = this.prefetchListing.bind(this);
     this.updateBackgroundImage();
   }
 
-  getBackgroundImage({
-    endpoint = 'https://source.unsplash.com/random',
-    searchKeyword = 'nature,water,cat'
+  async updateBackgroundImage() {
+    let dailyImages = await this.getDailyListing();
+    let image = dailyImages[Math.floor(Math.random() * dailyImages.length)];
+
+    this.element.background.classList.add('loaded');
+    this.element.background.style.backgroundImage = `url('${image.urls.regular}')`;
+    this.element.backgroundInfo.href = image.links.html;
+    this.element.backgroundInfo.textContent = `${image.user.name} / Unsplash`;
+    window.requestIdleCallback(this.prefetchListing, { timeout: 1000 });
+  }
+
+  getDailyUniqueId() {
+    // Get timestamp for today and yesterday's 00:00:00
+    let today = Date.parse(new Date().toDateString());
+    let yesterday = (today - 86400000);
+    let postfix = this.prefetchPostfix;
+    return {
+      uidToday: `${today.toString(36)}-${postfix}`,
+      uidYesterday: `${yesterday.toString(36)}-${postfix}`
+    };
+  }
+
+  getDailyListing() {
+    let { uidToday, uidYesterday } = this.getDailyUniqueId();
+    return new Promise((resolve, reject) => {
+      chrome.storage.local.get([uidToday, uidYesterday], async (result) => {
+        if (result[uidToday]) {
+          resolve(result[uidToday].list);
+        } else {
+          let useNewListing = true;
+          if (result[uidYesterday]) {
+            useNewListing = false;
+            resolve(result[uidYesterday].list);
+          }
+          let list = await this.fetchNewListing({ uid: uidToday });
+          chrome.storage.local.set({ [uidToday]: { prefetched: [], list } });
+          useNewListing && resolve(list);
+        }
+        result[uidYesterday] && this.removeExpiredListing();
+      });
+    });
+  }
+
+  async fetchNewListing({
+    fallbackData = [
+      { "id": "cWOzOnSoh6Q", "color": "#FADFC9", "urls": { "raw": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6", "full": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&s=e12a6a9d085f220f14e134d1353b77a2", "regular": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=59286c03c919f402f4c5119fdbae385b", "small": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&s=96212622ffb7186d14f65748393cd2f9", "thumb": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&s=27403b3f88e194bf108787a2a3d23164" }, "links": { "html": "https://unsplash.com/photos/cWOzOnSoh6Q", "download": "https://unsplash.com/photos/cWOzOnSoh6Q/download", "download_location": "api.unsplash.com/photos/cWOzOnSoh6Q/download" }, "user": { "name": "Pacto Visual" } }
+    ],
+    cid = '797b6d75b81b6d17621bb0fad6c03db647182457de78e063e33806a5b273ce35',
   } = {}) {
-    let request = new Request(`${endpoint}/?${searchKeyword}`);
-    return fetch(request, { mode: 'cors', cache: 'default' })
+    let searchKeyword = await this.getSearchKeyword();
+    let queryParameters = [
+      'count=15',
+      'featured=true',
+      `query=${searchKeyword}`
+    ].join('&');
+    let apiEndpoint = 'https://api.unsplash.com/photos/random';
+    let request = new Request(`${apiEndpoint}/?${queryParameters}`);
+    request.headers.append('Authorization', `Client-ID ${cid}`);
+
+    return fetch(request)
       .then((resp) => {
-        return { imageUrl: resp.url };
+        if (resp.ok) {
+          return resp.json();
+        } else {
+          throw new Error(`${resp.status} ${resp.statusText}`);
+        }
       })
       .catch((err) => {
         console.error(err);
-        return { imageUrl: 'https://source.unsplash.com/random'};
+        return fallbackData;
       });
   }
 
-  async updateBackgroundImage() {
-    let { searchKeyword } = await this.getPreference();
-    let { imageUrl } = await this.getBackgroundImage({ searchKeyword });
-    this.element.background.classList.add('loaded');
-    this.element.background.style.backgroundImage = `url('${imageUrl}')`;
+  async prefetchListing() {
+    let { uidToday } = this.getDailyUniqueId();
+    chrome.storage.local.get(uidToday, (result) => {
+      let prefetched = [];
+      let daily = result[uidToday];
+      if (!daily || !daily.list || daily.prefetched.length >= daily.list.length) return;
+      Promise.all(daily.list.map((item, index) => {
+        if (daily.prefetched.includes(index)) return Promise.resolve();
+        return fetch(item.urls.regular)
+          .then(prefetched.push(index))
+          .catch((err) => {
+            console.error(`Error prefetching ${item.urls.regular}:`, err);
+          });
+      })).then(() => {
+        chrome.storage.local.set({
+          [uidToday]: { prefetched, list: daily.list }
+        });
+      });
+    });
   }
 
-  getPreference() {
+  removeExpiredListing({ removeAll = false } = {}) {
+    let { uidToday } = this.getDailyUniqueId();
+    chrome.storage.local.get((result) => {
+      Object.keys(result).filter((key) => {
+        return removeAll ?
+          key.endsWith(this.prefetchPostfix) :
+          key.endsWith(this.prefetchPostfix) && key !== uidToday;
+      }).forEach((key) => {
+        chrome.storage.local.remove(key);
+      });
+    });
+  }
+
+  getSearchKeyword() {
     return new Promise((resolve, reject) => {
-      chrome.storage.local.get((result) => {
-        resolve(result);
+      chrome.storage.local.get('searchKeyword', (result) => {
+        if (result.searchKeyword) {
+          resolve(result.searchKeyword)
+        } else {
+          let defaultSearchKeyword = 'nature,water,cat';
+          chrome.storage.local.set({ searchKeyword: defaultSearchKeyword });
+          resolve(defaultSearchKeyword);
+        }
       });
     });
   }

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -1,13 +1,26 @@
 class Preferences {
   static saveOptions(event) {
+    chrome.storage.local.get((result) => {
+      Object.keys(result).filter((key) => {
+        return key.endsWith('yuman-prefetch-v1');
+      }).forEach((key) => {
+        chrome.storage.local.remove(key);
+      });
+    });
     chrome.storage.local.set({
       searchKeyword: document.querySelector('#search-keyword').value
     });
   }
 
   static loadOptions() {
-    chrome.storage.local.get((result) => {
-      document.querySelector('#search-keyword').value = result.queryKeywords || 'nature,water,cat';
+    chrome.storage.local.get('searchKeyword', (result) => {
+      if (result.searchKeyword) {
+        document.querySelector('#search-keyword').value = result.searchKeyword;
+      } else {
+        let defaultSearchKeyword = 'nature,water,cat';
+        chrome.storage.local.set({ searchKeyword: defaultSearchKeyword });
+        document.querySelector('#search-keyword').value = defaultSearchKeyword;
+      }
     });
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Yuman",
-  "version": "2.0",
+  "version": "2.0.1",
   "manifest_version": 2,
   "description": "Yuman collects high-resolution photos from unsplash.com and makes your new tabs more beautiful.",
   "icons": {
@@ -8,6 +8,11 @@
     "48": "icons/icon48.png",
     "64": "icons/icon64.png",
     "96": "icons/icon96.png"
+  },
+  "applications": {
+    "gecko": {
+      "strict_min_version": "54.0"
+    }
   },
   "permissions": [
     "storage"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Yuman",
-  "version": "2.0.1",
+  "version": "2.0.2.2",
   "manifest_version": 2,
   "description": "Yuman collects high-resolution photos from unsplash.com and makes your new tabs more beautiful.",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "seiyugi",
   "email": "debuguy@debuguy.org",
   "license": "MPL 2.0",
-  "version": "2.0",
+  "version": "2.0.1",
   "icon": "icons/icon64.png"
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "seiyugi",
   "email": "debuguy@debuguy.org",
   "license": "MPL 2.0",
-  "version": "2.0.1",
+  "version": "2.0.2.2",
   "icon": "icons/icon64.png"
 }


### PR DESCRIPTION
This pr will try to cover following changes:
  - Use Unsplash API to get 15 images every day, images will be prefetched and cached.
  - Cache will invalid on new daily images arrive.
  - Give attribution for image source.
  - Fix preference's bug.

Please note first time loading speed may still slow.

A quick demo: https://www.youtube.com/watch?v=JLV8ahgnxLY
Try it on: https://addons.mozilla.org/en-US/firefox/addon/yuman-prerelease/
