### PR TITLE
Update Unsplash API and preference page

### DIFF
--- a/css/preferences.css
+++ b/css/preferences.css
@@ -1,5 +1,5 @@
 .root {
-  font-size: 14px;
+    font-size: 14px;
 }
 
 input[type=text] {
@@ -25,4 +25,15 @@ input[type=text] {
     padding: 0 10px;
     text-shadow: none;
     background: none;
+}
+
+.saveStatus {
+    background-color: #dff0d8;
+    margin-left: 10px;
+    padding: 3px 5px;
+    display: none;
+}
+
+.saveStatus.show {
+    display: initial;
 }

--- a/js/index.js
+++ b/js/index.js
@@ -64,7 +64,6 @@ class NewTab {
     let searchKeyword = await this.getSearchKeyword();
     let queryParameters = [
       'count=15',
-      'featured=true',
       `query=${searchKeyword}`
     ].join('&');
     let apiEndpoint = 'https://api.unsplash.com/photos/random';

--- a/js/index.js
+++ b/js/index.js
@@ -18,7 +18,7 @@ class NewTab {
 
     this.element.background.classList.add('loaded');
     this.element.background.style.backgroundImage = `url('${image.urls.regular}')`;
-    this.element.backgroundInfo.href = image.links.html;
+    this.element.backgroundInfo.href = `${image.user.links.html}?utm_source=yuman_chrome_extension&utm_medium=referral`;
     this.element.backgroundInfo.textContent = `${image.user.name} / Unsplash`;
     window.requestIdleCallback(this.prefetchListing, { timeout: 1000 });
   }
@@ -57,7 +57,7 @@ class NewTab {
 
   async fetchNewListing({
     fallbackData = [
-      { "id": "cWOzOnSoh6Q", "color": "#FADFC9", "urls": { "raw": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6", "full": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&s=e12a6a9d085f220f14e134d1353b77a2", "regular": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=59286c03c919f402f4c5119fdbae385b", "small": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&s=96212622ffb7186d14f65748393cd2f9", "thumb": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&s=27403b3f88e194bf108787a2a3d23164" }, "links": { "html": "https://unsplash.com/photos/cWOzOnSoh6Q", "download": "https://unsplash.com/photos/cWOzOnSoh6Q/download", "download_location": "api.unsplash.com/photos/cWOzOnSoh6Q/download" }, "user": { "name": "Pacto Visual" } }
+      { "id": "cWOzOnSoh6Q", "color": "#FADFC9", "urls": { "raw": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6", "full": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=85&fm=jpg&crop=entropy&cs=srgb&s=e12a6a9d085f220f14e134d1353b77a2", "regular": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=1080&fit=max&s=59286c03c919f402f4c5119fdbae385b", "small": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=400&fit=max&s=96212622ffb7186d14f65748393cd2f9", "thumb": "https://images.unsplash.com/photo-1478098711619-5ab0b478d6e6?ixlib=rb-0.3.5&q=80&fm=jpg&crop=entropy&cs=tinysrgb&w=200&fit=max&s=27403b3f88e194bf108787a2a3d23164" }, "links": { "html": "https://unsplash.com/photos/cWOzOnSoh6Q", "download": "https://unsplash.com/photos/cWOzOnSoh6Q/download", "download_location": "api.unsplash.com/photos/cWOzOnSoh6Q/download" }, "user": { "links": { "html": "https://unsplash.com/@pactovisual" }, "name": "Pacto Visual" } }
     ],
     cid = '797b6d75b81b6d17621bb0fad6c03db647182457de78e063e33806a5b273ce35',
   } = {}) {

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -1,5 +1,6 @@
 class Preferences {
   static saveOptions(event) {
+    document.querySelector('.saveStatus').classList.add('show');
     chrome.storage.local.get((result) => {
       Object.keys(result).filter((key) => {
         return key.endsWith('yuman-prefetch-v1');
@@ -9,6 +10,10 @@ class Preferences {
     });
     chrome.storage.local.set({
       searchKeyword: document.querySelector('#search-keyword').value
+    }, () => {
+      window.setTimeout(() => {
+        document.querySelector('.saveStatus').classList.remove('show');
+      }, 1000);
     });
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Yuman",
-  "version": "2.0.2.2",
+  "version": "2.0.4",
   "manifest_version": 2,
   "description": "Yuman collects high-resolution photos from unsplash.com and makes your new tabs more beautiful.",
   "icons": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "seiyugi",
   "email": "debuguy@debuguy.org",
   "license": "MPL 2.0",
-  "version": "2.0.2.2",
+  "version": "2.0.4",
   "icon": "icons/icon64.png"
 }

--- a/preferences.html
+++ b/preferences.html
@@ -11,6 +11,7 @@
     <label>Image topics: <input type="text" id="search-keyword" /></label>
     <br />
     <a id="saveOptions" class="button">Save</a>
+    <span class="saveStatus">Options saved.</span>
   </div>
   <script defer src="js/preferences.js"></script>
 </body>


### PR DESCRIPTION
This pr covers following changes:
  - Change attribution link and add utm parameter to comply with unsplash API guideline.
    Note: This will unlock production API limits and have more requests available per hour.
  - Remove `featured=true` from API query parameter to get better search result.
  - Show notice on preference saved.

Screenshot:
<img width="404" alt="screen shot 2017-12-15 at 15 14 13" src="https://user-images.githubusercontent.com/582218/34029232-b980763e-e1aa-11e7-8585-fe4718c11856.png">
